### PR TITLE
bump kong to 0.6.0rc2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mashape/kong:0.5.3
+FROM mashape/kong:0.6.0rc2
 MAINTAINER Brian Stolz, bstolz@articulate.com
 
 ENV CASSANDRA_HOSTNAME cassandra


### PR DESCRIPTION
![kong](http://1mpr64kkw06av2tn1d975o3k.wpengine.netdna-cdn.com/wp-content/uploads/2012/03/Classic-KONG1-700x700.jpg)
